### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/minifold/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-
-
-## License
-
-This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/minifold/blob/master/LICENSE).

--- a/README.rst
+++ b/README.rst
@@ -44,3 +44,9 @@ For more information, feel free to visit the wiki_:
 - Design_
 - Framework_
 - Tests_
+
+=======
+License
+=======
+
+This project is licensed under the BSD-3-Clause license - see the `LICENSE <https://github.com/nokia/minifold/blob/master/LICENSE>`_.


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.